### PR TITLE
Fix from_json test in R to check NA not the exception

### DIFF
--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -1354,9 +1354,8 @@ test_that("column functions", {
   # passing option
   df <- as.DataFrame(list(list("col" = "{\"date\":\"21/10/2014\"}")))
   schema2 <- structType(structField("date", "date"))
-  expect_error(tryCatch(collect(select(df, from_json(df$col, schema2))),
-                        error = function(e) { stop(e) }),
-               paste0(".*(java.lang.NumberFormatException: For input string:).*"))
+  s <- collect(select(df, from_json(df$col, schema2)))
+  expect_equal(s[[1]][[1]], NA)
   s <- collect(select(df, from_json(df$col, schema2, dateFormat = "dd/MM/yyyy")))
   expect_is(s[[1]][[1]]$date, "Date")
   expect_equal(as.character(s[[1]][[1]]$date), "2014-10-21")


### PR DESCRIPTION
Previously, when `DateType` is explicitly given and the data is not parseable into a date, it seems it throws an `NumberFormatException` in https://github.com/apache/spark/blob/769aa0f1d22d3c6d4c7871468344d82c8dc36260/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala#L315 regardless of `parseMode`.

as below:

```scala
import org.apache.spark.sql.types._
spark.read.schema(StructType(StructField("date", DateType) :: Nil)).json(Seq("{\"date\":\"21/10/2014\"}").toDS).show()
```

prints

```
ERROR Executor: Exception in task 0.0 in stage 1.0 (TID 1)
java.lang.NumberFormatException: For input string: "21/10/2014"
```

Now, `RuntimeException` is caught and `NumberFormatException` is a `RuntimeException` and they are caught and it now returns `null` in this case.

This seems correct according to https://github.com/apache/spark/blob/369a148e591bb16ec7da54867610b207602cd698/sql/core/src/main/scala/org/apache/spark/sql/functions.scala#L2966. So, this PR proposes to fix the R test.
