### PR TITLE
Work around astype with columns in Pandas < 0.19.0

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1731,7 +1731,7 @@ class DataFrame(object):
         pdf = pd.DataFrame.from_records(self.collect(), columns=self.columns)
 
         for f, t in dtype.items():
-            pdf[f] = pdf[f].astype(t)
+            pdf[f] = pdf[f].astype(t, copy=False)
         return pdf
 
     ##########################################################################################

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1725,11 +1725,14 @@ class DataFrame(object):
         dtype = {}
         for field in self.schema:
             pandas_type = _to_corrected_pandas_type(field.dataType)
-            if (pandas_type):
+            if pandas_type is not None:
                 dtype[field.name] = pandas_type
 
-        df = pd.DataFrame.from_records(self.collect(), columns=self.columns)
-        return df.astype(dtype, copy=False)
+        pdf = pd.DataFrame.from_records(self.collect(), columns=self.columns)
+
+        for f, t in dtype.items():
+            pdf[f] = pdf[f].astype(t)
+        return pdf
 
     ##########################################################################################
     # Pandas compatibility


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the codes below fails in Pandas < 0.19.0 

```python
from pyspark.sql.types import *

schema = StructType().add("a", IntegerType()).add("b", StringType())\
                     .add("c", BooleanType()).add("d", FloatType())
data = [
    (1, "foo", True, 3.0,), (2, "foo", True, 5.0),
    (3, "bar", False, -1.0), (4, "bar", False, 6.0),
]
spark.createDataFrame(data, schema).toPandas().dtypes
```

This looks because this was added from 0.19.0 (astype with dict). This PR proposes to manually work around by for loop.


**Before (pandas < 0.19.0)**:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/hyukjinkwon/Desktop/workspace/repos/forked/spark/python/pyspark/sql/dataframe.py", line 1731, in toPandas
    return pd.DataFrame.from_records(self.collect(), columns=self.columns).astype(dtype)
  File "/Library/Python/2.7/site-packages/pandas/core/generic.py", line 2950, in astype
    raise_on_error=raise_on_error, **kwargs)
  File "/Library/Python/2.7/site-packages/pandas/core/internals.py", line 2938, in astype
    return self.apply('astype', dtype=dtype, **kwargs)
  File "/Library/Python/2.7/site-packages/pandas/core/internals.py", line 2890, in apply
    applied = getattr(b, f)(**kwargs)
  File "/Library/Python/2.7/site-packages/pandas/core/internals.py", line 434, in astype
    values=values, **kwargs)
  File "/Library/Python/2.7/site-packages/pandas/core/internals.py", line 449, in _astype
    dtype = np.dtype(dtype)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/numpy/core/_internal.py", line 61, in _usefields
    names, formats, offsets, titles = _makenames_list(adict, align)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/numpy/core/_internal.py", line 26, in _makenames_list
    n = len(obj)
TypeError: object of type 'type' has no len()
```

**After (tested on Pandas 0.18.1 and 0.20.2)**:

```
a      int32
b     object
c       bool
d    float32
dtype: object
```

## How was this patch tested?

Manually tested.

