### PR TITLE
UT and double check for SPARK-25896

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -2011,7 +2011,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
   test("accumulator not calculated for resubmitted task in shuffle map stage") {
     val accum = AccumulatorSuite.createLongAccum("a")
-    // Create a shuffleMapRdd with 1 partition
+    // Create a shuffleMapRdd with 2 partition
     val shuffleMapRdd = new MyRDD(sc, 2, Nil)
     val shuffleDep = new ShuffleDependency(shuffleMapRdd, new HashPartitioner(1))
     val shuffleId = shuffleDep.shuffleId


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add UT to check:
1. Accumulator only updated once.
2. Map status overwrite by last success task.

## How was this patch tested?

New UT
