### PR TITLE
Results of DateTimeRebaseBenchmark on JDK 8 and 11

### DIFF
--- a/sql/core/benchmarks/DateTimeRebaseBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/DateTimeRebaseBenchmark-jdk11-results.txt
@@ -2,93 +2,93 @@
 Rebasing dates/timestamps in Parquet datasource
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save dates to parquet:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                  21171          21171           0          4.7         211.7       1.0X
-before 1582, noop                                 11036          11036           0          9.1         110.4       1.9X
-after 1582, rebase off                            34321          34321           0          2.9         343.2       0.6X
-after 1582, rebase on                             33269          33269           0          3.0         332.7       0.6X
-before 1582, rebase off                           22016          22016           0          4.5         220.2       1.0X
-before 1582, rebase on                            23338          23338           0          4.3         233.4       0.9X
+after 1582, noop                                  18169          18169           0          5.5         181.7       1.0X
+before 1582, noop                                 10714          10714           0          9.3         107.1       1.7X
+after 1582, rebase off                            30369          30369           0          3.3         303.7       0.6X
+after 1582, rebase on                             30956          30956           0          3.2         309.6       0.6X
+before 1582, rebase off                           22845          22845           0          4.4         228.4       0.8X
+before 1582, rebase on                            24076          24076           0          4.2         240.8       0.8X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load dates from parquet:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off, rebase off                   12791          13089         287          7.8         127.9       1.0X
-after 1582, vec off, rebase on                    13203          13271          81          7.6         132.0       1.0X
-after 1582, vec on, rebase off                     3709           3764          49         27.0          37.1       3.4X
-after 1582, vec on, rebase on                      5082           5114          29         19.7          50.8       2.5X
-before 1582, vec off, rebase off                  13059          13153          87          7.7         130.6       1.0X
-before 1582, vec off, rebase on                   14211          14236          27          7.0         142.1       0.9X
-before 1582, vec on, rebase off                    3687           3749          72         27.1          36.9       3.5X
-before 1582, vec on, rebase on                     5449           5497          56         18.4          54.5       2.3X
+after 1582, vec off, rebase off                   12764          12825          84          7.8         127.6       1.0X
+after 1582, vec off, rebase on                    13593          13689          85          7.4         135.9       0.9X
+after 1582, vec on, rebase off                     3692           3731          37         27.1          36.9       3.5X
+after 1582, vec on, rebase on                      3771           3777           7         26.5          37.7       3.4X
+before 1582, vec off, rebase off                  13333          13363          49          7.5         133.3       1.0X
+before 1582, vec off, rebase on                   14033          14139         158          7.1         140.3       0.9X
+before 1582, vec on, rebase off                    3704           3724          19         27.0          37.0       3.4X
+before 1582, vec on, rebase on                     4318           4345          41         23.2          43.2       3.0X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save timestamps to parquet:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                   2831           2831           0         35.3          28.3       1.0X
-before 1582, noop                                  2816           2816           0         35.5          28.2       1.0X
-after 1582, rebase off                            15543          15543           0          6.4         155.4       0.2X
-after 1582, rebase on                             18391          18391           0          5.4         183.9       0.2X
-before 1582, rebase off                           15747          15747           0          6.4         157.5       0.2X
-before 1582, rebase on                            18846          18846           0          5.3         188.5       0.2X
+after 1900, noop                                   2826           2826           0         35.4          28.3       1.0X
+before 1900, noop                                  2795           2795           0         35.8          27.9       1.0X
+after 1900, rebase off                            16935          16935           0          5.9         169.3       0.2X
+after 1900, rebase on                             18874          18874           0          5.3         188.7       0.1X
+before 1900, rebase off                           17297          17297           0          5.8         173.0       0.2X
+before 1900, rebase on                            20261          20261           0          4.9         202.6       0.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load timestamps from parquet:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off, rebase off                   16126          16216          78          6.2         161.3       1.0X
-after 1582, vec off, rebase on                    18277          18453         165          5.5         182.8       0.9X
-after 1582, vec on, rebase off                     5030           5067          42         19.9          50.3       3.2X
-after 1582, vec on, rebase on                      8553           8583          43         11.7          85.5       1.9X
-before 1582, vec off, rebase off                  15828          15872          39          6.3         158.3       1.0X
-before 1582, vec off, rebase on                   18899          18959         103          5.3         189.0       0.9X
-before 1582, vec on, rebase off                    4961           5009          43         20.2          49.6       3.3X
-before 1582, vec on, rebase on                     9099           9140          40         11.0          91.0       1.8X
+after 1900, vec off, rebase off                   15164          15215          44          6.6         151.6       1.0X
+after 1900, vec off, rebase on                    17485          17502          25          5.7         174.8       0.9X
+after 1900, vec on, rebase off                     4960           4993          33         20.2          49.6       3.1X
+after 1900, vec on, rebase on                      4975           5022          41         20.1          49.7       3.0X
+before 1900, vec off, rebase off                  15036          15102          57          6.7         150.4       1.0X
+before 1900, vec off, rebase on                   17879          18075         199          5.6         178.8       0.8X
+before 1900, vec on, rebase off                    5007           5040          36         20.0          50.1       3.0X
+before 1900, vec on, rebase on                     8086           8106          18         12.4          80.9       1.9X
 
 
 ================================================================================================
 Rebasing dates/timestamps in ORC datasource
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save dates to ORC:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                  21026          21026           0          4.8         210.3       1.0X
-before 1582, noop                                 11040          11040           0          9.1         110.4       1.9X
-after 1582                                        28171          28171           0          3.5         281.7       0.7X
-before 1582                                       18955          18955           0          5.3         189.5       1.1X
+after 1582, noop                                  17884          17884           0          5.6         178.8       1.0X
+before 1582, noop                                 10446          10446           0          9.6         104.5       1.7X
+after 1582                                        26287          26287           0          3.8         262.9       0.7X
+before 1582                                       19133          19133           0          5.2         191.3       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load dates from ORC:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off                               10876          10931          49          9.2         108.8       1.0X
-after 1582, vec on                                 3900           3913          20         25.6          39.0       2.8X
-before 1582, vec off                              11165          11174          12          9.0         111.6       1.0X
-before 1582, vec on                                4208           4214           7         23.8          42.1       2.6X
+after 1582, vec off                               10359          10433          80          9.7         103.6       1.0X
+after 1582, vec on                                 3933           3947          12         25.4          39.3       2.6X
+before 1582, vec off                              10808          10888          70          9.3         108.1       1.0X
+before 1582, vec on                                4235           4312          67         23.6          42.4       2.4X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save timestamps to ORC:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                   2924           2924           0         34.2          29.2       1.0X
-before 1582, noop                                  2820           2820           0         35.5          28.2       1.0X
-after 1582                                        22228          22228           0          4.5         222.3       0.1X
-before 1582                                       22590          22590           0          4.4         225.9       0.1X
+after 1900, noop                                   2889           2889           0         34.6          28.9       1.0X
+before 1900, noop                                  2750           2750           0         36.4          27.5       1.1X
+after 1900                                        20029          20029           0          5.0         200.3       0.1X
+before 1900                                       21017          21017           0          4.8         210.2       0.1X
 
-OpenJDK 64-Bit Server VM 11.0.6+10-post-Ubuntu-1ubuntu118.04.1 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load timestamps from ORC:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off                               13591          13658          59          7.4         135.9       1.0X
-after 1582, vec on                                 7399           7488         126         13.5          74.0       1.8X
-before 1582, vec off                              14065          14096          30          7.1         140.7       1.0X
-before 1582, vec on                                7950           8127         249         12.6          79.5       1.7X
+after 1900, vec off                               13920          13957          56          7.2         139.2       1.0X
+after 1900, vec on                                 7240           7252          11         13.8          72.4       1.9X
+before 1900, vec off                              14290          14422         173          7.0         142.9       1.0X
+before 1900, vec on                                7798           7829          47         12.8          78.0       1.8X
 
 

--- a/sql/core/benchmarks/DateTimeRebaseBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/DateTimeRebaseBenchmark-jdk11-results.txt
@@ -6,49 +6,49 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save dates to parquet:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                  18169          18169           0          5.5         181.7       1.0X
-before 1582, noop                                 10714          10714           0          9.3         107.1       1.7X
-after 1582, rebase off                            30369          30369           0          3.3         303.7       0.6X
-after 1582, rebase on                             30956          30956           0          3.2         309.6       0.6X
-before 1582, rebase off                           22845          22845           0          4.4         228.4       0.8X
-before 1582, rebase on                            24076          24076           0          4.2         240.8       0.8X
+after 1582, noop                                  20073          20073           0          5.0         200.7       1.0X
+before 1582, noop                                 10985          10985           0          9.1         109.9       1.8X
+after 1582, rebase off                            32245          32245           0          3.1         322.4       0.6X
+after 1582, rebase on                             31434          31434           0          3.2         314.3       0.6X
+before 1582, rebase off                           21590          21590           0          4.6         215.9       0.9X
+before 1582, rebase on                            22963          22963           0          4.4         229.6       0.9X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load dates from parquet:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off, rebase off                   12764          12825          84          7.8         127.6       1.0X
-after 1582, vec off, rebase on                    13593          13689          85          7.4         135.9       0.9X
-after 1582, vec on, rebase off                     3692           3731          37         27.1          36.9       3.5X
-after 1582, vec on, rebase on                      3771           3777           7         26.5          37.7       3.4X
-before 1582, vec off, rebase off                  13333          13363          49          7.5         133.3       1.0X
-before 1582, vec off, rebase on                   14033          14139         158          7.1         140.3       0.9X
-before 1582, vec on, rebase off                    3704           3724          19         27.0          37.0       3.4X
-before 1582, vec on, rebase on                     4318           4345          41         23.2          43.2       3.0X
+after 1582, vec off, rebase off                   12815          12858          40          7.8         128.1       1.0X
+after 1582, vec off, rebase on                    13030          13167         148          7.7         130.3       1.0X
+after 1582, vec on, rebase off                     3705           3712           6         27.0          37.1       3.5X
+after 1582, vec on, rebase on                      3788           3791           3         26.4          37.9       3.4X
+before 1582, vec off, rebase off                  12873          12943          61          7.8         128.7       1.0X
+before 1582, vec off, rebase on                   14072          14165          80          7.1         140.7       0.9X
+before 1582, vec on, rebase off                    3694           3708          15         27.1          36.9       3.5X
+before 1582, vec on, rebase on                     4403           4484          81         22.7          44.0       2.9X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save timestamps to parquet:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1900, noop                                   2826           2826           0         35.4          28.3       1.0X
-before 1900, noop                                  2795           2795           0         35.8          27.9       1.0X
-after 1900, rebase off                            16935          16935           0          5.9         169.3       0.2X
-after 1900, rebase on                             18874          18874           0          5.3         188.7       0.1X
-before 1900, rebase off                           17297          17297           0          5.8         173.0       0.2X
-before 1900, rebase on                            20261          20261           0          4.9         202.6       0.1X
+after 1900, noop                                   3032           3032           0         33.0          30.3       1.0X
+before 1900, noop                                  3043           3043           0         32.9          30.4       1.0X
+after 1900, rebase off                            15634          15634           0          6.4         156.3       0.2X
+after 1900, rebase on                             18233          18233           0          5.5         182.3       0.2X
+before 1900, rebase off                           15820          15820           0          6.3         158.2       0.2X
+before 1900, rebase on                            19921          19921           0          5.0         199.2       0.2X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load timestamps from parquet:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1900, vec off, rebase off                   15164          15215          44          6.6         151.6       1.0X
-after 1900, vec off, rebase on                    17485          17502          25          5.7         174.8       0.9X
-after 1900, vec on, rebase off                     4960           4993          33         20.2          49.6       3.1X
-after 1900, vec on, rebase on                      4975           5022          41         20.1          49.7       3.0X
-before 1900, vec off, rebase off                  15036          15102          57          6.7         150.4       1.0X
-before 1900, vec off, rebase on                   17879          18075         199          5.6         178.8       0.8X
-before 1900, vec on, rebase off                    5007           5040          36         20.0          50.1       3.0X
-before 1900, vec on, rebase on                     8086           8106          18         12.4          80.9       1.9X
+after 1900, vec off, rebase off                   14987          15008          18          6.7         149.9       1.0X
+after 1900, vec off, rebase on                    17500          17628         210          5.7         175.0       0.9X
+after 1900, vec on, rebase off                     5030           5036           7         19.9          50.3       3.0X
+after 1900, vec on, rebase on                      5066           5109          44         19.7          50.7       3.0X
+before 1900, vec off, rebase off                  15094          15213         121          6.6         150.9       1.0X
+before 1900, vec off, rebase on                   18098          18175         101          5.5         181.0       0.8X
+before 1900, vec on, rebase off                    5008           5012           4         20.0          50.1       3.0X
+before 1900, vec on, rebase on                     8803           8848          55         11.4          88.0       1.7X
 
 
 ================================================================================================
@@ -59,36 +59,36 @@ OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-106
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save dates to ORC:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                  17884          17884           0          5.6         178.8       1.0X
-before 1582, noop                                 10446          10446           0          9.6         104.5       1.7X
-after 1582                                        26287          26287           0          3.8         262.9       0.7X
-before 1582                                       19133          19133           0          5.2         191.3       0.9X
+after 1582, noop                                  19593          19593           0          5.1         195.9       1.0X
+before 1582, noop                                 10581          10581           0          9.5         105.8       1.9X
+after 1582                                        27843          27843           0          3.6         278.4       0.7X
+before 1582                                       19435          19435           0          5.1         194.4       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load dates from ORC:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off                               10359          10433          80          9.7         103.6       1.0X
-after 1582, vec on                                 3933           3947          12         25.4          39.3       2.6X
-before 1582, vec off                              10808          10888          70          9.3         108.1       1.0X
-before 1582, vec on                                4235           4312          67         23.6          42.4       2.4X
+after 1582, vec off                               10395          10507         119          9.6         103.9       1.0X
+after 1582, vec on                                 3921           3945          22         25.5          39.2       2.7X
+before 1582, vec off                              10762          10860         127          9.3         107.6       1.0X
+before 1582, vec on                                4194           4226          41         23.8          41.9       2.5X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save timestamps to ORC:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1900, noop                                   2889           2889           0         34.6          28.9       1.0X
-before 1900, noop                                  2750           2750           0         36.4          27.5       1.1X
-after 1900                                        20029          20029           0          5.0         200.3       0.1X
-before 1900                                       21017          21017           0          4.8         210.2       0.1X
+after 1900, noop                                   3003           3003           0         33.3          30.0       1.0X
+before 1900, noop                                  3016           3016           0         33.2          30.2       1.0X
+after 1900                                        21804          21804           0          4.6         218.0       0.1X
+before 1900                                       23920          23920           0          4.2         239.2       0.1X
 
 OpenJDK 64-Bit Server VM 11.0.7+10-post-Ubuntu-2ubuntu218.04 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load timestamps from ORC:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1900, vec off                               13920          13957          56          7.2         139.2       1.0X
-after 1900, vec on                                 7240           7252          11         13.8          72.4       1.9X
-before 1900, vec off                              14290          14422         173          7.0         142.9       1.0X
-before 1900, vec on                                7798           7829          47         12.8          78.0       1.8X
+after 1900, vec off                               14112          14128          17          7.1         141.1       1.0X
+after 1900, vec on                                 7347           7459         134         13.6          73.5       1.9X
+before 1900, vec off                              15170          15192          27          6.6         151.7       0.9X
+before 1900, vec on                                8280           8312          52         12.1          82.8       1.7X
 
 

--- a/sql/core/benchmarks/DateTimeRebaseBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeRebaseBenchmark-results.txt
@@ -6,49 +6,49 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save dates to parquet:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                  23462          23462           0          4.3         234.6       1.0X
-before 1582, noop                                 10591          10591           0          9.4         105.9       2.2X
-after 1582, rebase off                            35513          35513           0          2.8         355.1       0.7X
-after 1582, rebase on                             35354          35354           0          2.8         353.5       0.7X
-before 1582, rebase off                           21778          21778           0          4.6         217.8       1.1X
-before 1582, rebase on                            22715          22715           0          4.4         227.1       1.0X
+after 1582, noop                                  23088          23088           0          4.3         230.9       1.0X
+before 1582, noop                                 10782          10782           0          9.3         107.8       2.1X
+after 1582, rebase off                            34821          34821           0          2.9         348.2       0.7X
+after 1582, rebase on                             35040          35040           0          2.9         350.4       0.7X
+before 1582, rebase off                           22151          22151           0          4.5         221.5       1.0X
+before 1582, rebase on                            24677          24677           0          4.1         246.8       0.9X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load dates from parquet:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off, rebase off                   13233          13324          79          7.6         132.3       1.0X
-after 1582, vec off, rebase on                    13266          13368         154          7.5         132.7       1.0X
-after 1582, vec on, rebase off                     3644           3647           4         27.4          36.4       3.6X
-after 1582, vec on, rebase on                      3784           3799          14         26.4          37.8       3.5X
-before 1582, vec off, rebase off                  12961          13090         124          7.7         129.6       1.0X
-before 1582, vec off, rebase on                   13835          13948         100          7.2         138.3       1.0X
-before 1582, vec on, rebase off                    3584           3609          22         27.9          35.8       3.7X
-before 1582, vec on, rebase on                     4455           4463          11         22.4          44.6       3.0X
+after 1582, vec off, rebase off                   13559          13650          79          7.4         135.6       1.0X
+after 1582, vec off, rebase on                    12942          12973          28          7.7         129.4       1.0X
+after 1582, vec on, rebase off                     3657           3689          29         27.3          36.6       3.7X
+after 1582, vec on, rebase on                      3859           3902          53         25.9          38.6       3.5X
+before 1582, vec off, rebase off                  12588          12607          17          7.9         125.9       1.1X
+before 1582, vec off, rebase on                   13396          13420          25          7.5         134.0       1.0X
+before 1582, vec on, rebase off                    3631           3650          19         27.5          36.3       3.7X
+before 1582, vec on, rebase on                     4706           4755          77         21.3          47.1       2.9X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save timestamps to parquet:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1900, noop                                   2774           2774           0         36.1          27.7       1.0X
-before 1900, noop                                  2749           2749           0         36.4          27.5       1.0X
-after 1900, rebase off                            15787          15787           0          6.3         157.9       0.2X
-after 1900, rebase on                             18630          18630           0          5.4         186.3       0.1X
-before 1900, rebase off                           16188          16188           0          6.2         161.9       0.2X
-before 1900, rebase on                            19420          19420           0          5.1         194.2       0.1X
+after 1900, noop                                   2681           2681           0         37.3          26.8       1.0X
+before 1900, noop                                  3051           3051           0         32.8          30.5       0.9X
+after 1900, rebase off                            16901          16901           0          5.9         169.0       0.2X
+after 1900, rebase on                             19725          19725           0          5.1         197.3       0.1X
+before 1900, rebase off                           16900          16900           0          5.9         169.0       0.2X
+before 1900, rebase on                            20381          20381           0          4.9         203.8       0.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load timestamps from parquet:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1900, vec off, rebase off                   15144          15207          67          6.6         151.4       1.0X
-after 1900, vec off, rebase on                    18223          18334          98          5.5         182.2       0.8X
-after 1900, vec on, rebase off                     4871           4894          21         20.5          48.7       3.1X
-after 1900, vec on, rebase on                      5354           5362          10         18.7          53.5       2.8X
-before 1900, vec off, rebase off                  15088          15191         147          6.6         150.9       1.0X
-before 1900, vec off, rebase on                   18623          18688          64          5.4         186.2       0.8X
-before 1900, vec on, rebase off                    4870           4885          15         20.5          48.7       3.1X
-before 1900, vec on, rebase on                     9141           9286         132         10.9          91.4       1.7X
+after 1900, vec off, rebase off                   15236          15291          62          6.6         152.4       1.0X
+after 1900, vec off, rebase on                    17832          18047         187          5.6         178.3       0.9X
+after 1900, vec on, rebase off                     4875           4901          31         20.5          48.7       3.1X
+after 1900, vec on, rebase on                      5354           5386          37         18.7          53.5       2.8X
+before 1900, vec off, rebase off                  15229          15338         108          6.6         152.3       1.0X
+before 1900, vec off, rebase on                   18626          18668          44          5.4         186.3       0.8X
+before 1900, vec on, rebase off                    4968           4975           6         20.1          49.7       3.1X
+before 1900, vec on, rebase on                     9913           9932          16         10.1          99.1       1.5X
 
 
 ================================================================================================
@@ -59,36 +59,36 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save dates to ORC:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                  23275          23275           0          4.3         232.8       1.0X
-before 1582, noop                                 10491          10491           0          9.5         104.9       2.2X
-after 1582                                        31821          31821           0          3.1         318.2       0.7X
-before 1582                                       19826          19826           0          5.0         198.3       1.2X
+after 1582, noop                                  22942          22942           0          4.4         229.4       1.0X
+before 1582, noop                                 11035          11035           0          9.1         110.4       2.1X
+after 1582                                        31341          31341           0          3.2         313.4       0.7X
+before 1582                                       20376          20376           0          4.9         203.8       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load dates from ORC:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off                               10937          10957          22          9.1         109.4       1.0X
-after 1582, vec on                                 3728           3740          11         26.8          37.3       2.9X
-before 1582, vec off                              11445          11454           7          8.7         114.5       1.0X
-before 1582, vec on                                4096           4121          24         24.4          41.0       2.7X
+after 1582, vec off                               10361          10378          29          9.7         103.6       1.0X
+after 1582, vec on                                 3820           3828          11         26.2          38.2       2.7X
+before 1582, vec off                              10709          10720          13          9.3         107.1       1.0X
+before 1582, vec on                                4136           4153          15         24.2          41.4       2.5X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save timestamps to ORC:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1900, noop                                   2849           2849           0         35.1          28.5       1.0X
-before 1900, noop                                  2828           2828           0         35.4          28.3       1.0X
-after 1900                                        20289          20289           0          4.9         202.9       0.1X
-before 1900                                       20929          20929           0          4.8         209.3       0.1X
+after 1900, noop                                   2888           2888           0         34.6          28.9       1.0X
+before 1900, noop                                  2823           2823           0         35.4          28.2       1.0X
+after 1900                                        19790          19790           0          5.1         197.9       0.1X
+before 1900                                       20774          20774           0          4.8         207.7       0.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load timestamps from ORC:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1900, vec off                               15095          15160          63          6.6         151.0       1.0X
-after 1900, vec on                                 7834           7866          28         12.8          78.3       1.9X
-before 1900, vec off                              15631          15656          22          6.4         156.3       1.0X
-before 1900, vec on                                8305           8342          44         12.0          83.0       1.8X
+after 1900, vec off                               14649          14687          38          6.8         146.5       1.0X
+after 1900, vec on                                 7850           7937         130         12.7          78.5       1.9X
+before 1900, vec off                              15354          15417         108          6.5         153.5       1.0X
+before 1900, vec on                                8382           8408          22         11.9          83.8       1.7X
 
 

--- a/sql/core/benchmarks/DateTimeRebaseBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeRebaseBenchmark-results.txt
@@ -2,93 +2,93 @@
 Rebasing dates/timestamps in Parquet datasource
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save dates to parquet:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                  24114          24114           0          4.1         241.1       1.0X
-before 1582, noop                                 10250          10250           0          9.8         102.5       2.4X
-after 1582, rebase off                            36672          36672           0          2.7         366.7       0.7X
-after 1582, rebase on                             37123          37123           0          2.7         371.2       0.6X
-before 1582, rebase off                           21925          21925           0          4.6         219.2       1.1X
-before 1582, rebase on                            22341          22341           0          4.5         223.4       1.1X
+after 1582, noop                                  23462          23462           0          4.3         234.6       1.0X
+before 1582, noop                                 10591          10591           0          9.4         105.9       2.2X
+after 1582, rebase off                            35513          35513           0          2.8         355.1       0.7X
+after 1582, rebase on                             35354          35354           0          2.8         353.5       0.7X
+before 1582, rebase off                           21778          21778           0          4.6         217.8       1.1X
+before 1582, rebase on                            22715          22715           0          4.4         227.1       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load dates from parquet:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off, rebase off                   12456          12601         126          8.0         124.6       1.0X
-after 1582, vec off, rebase on                    13299          13336          32          7.5         133.0       0.9X
-after 1582, vec on, rebase off                     3623           3660          40         27.6          36.2       3.4X
-after 1582, vec on, rebase on                      5160           5177          15         19.4          51.6       2.4X
-before 1582, vec off, rebase off                  13177          13264          76          7.6         131.8       0.9X
-before 1582, vec off, rebase on                   14102          14149          46          7.1         141.0       0.9X
-before 1582, vec on, rebase off                    3649           3670          34         27.4          36.5       3.4X
-before 1582, vec on, rebase on                     5652           5667          15         17.7          56.5       2.2X
+after 1582, vec off, rebase off                   13233          13324          79          7.6         132.3       1.0X
+after 1582, vec off, rebase on                    13266          13368         154          7.5         132.7       1.0X
+after 1582, vec on, rebase off                     3644           3647           4         27.4          36.4       3.6X
+after 1582, vec on, rebase on                      3784           3799          14         26.4          37.8       3.5X
+before 1582, vec off, rebase off                  12961          13090         124          7.7         129.6       1.0X
+before 1582, vec off, rebase on                   13835          13948         100          7.2         138.3       1.0X
+before 1582, vec on, rebase off                    3584           3609          22         27.9          35.8       3.7X
+before 1582, vec on, rebase on                     4455           4463          11         22.4          44.6       3.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save timestamps to parquet:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                   2871           2871           0         34.8          28.7       1.0X
-before 1582, noop                                  2753           2753           0         36.3          27.5       1.0X
-after 1582, rebase off                            15927          15927           0          6.3         159.3       0.2X
-after 1582, rebase on                             19138          19138           0          5.2         191.4       0.1X
-before 1582, rebase off                           16137          16137           0          6.2         161.4       0.2X
-before 1582, rebase on                            19584          19584           0          5.1         195.8       0.1X
+after 1900, noop                                   2774           2774           0         36.1          27.7       1.0X
+before 1900, noop                                  2749           2749           0         36.4          27.5       1.0X
+after 1900, rebase off                            15787          15787           0          6.3         157.9       0.2X
+after 1900, rebase on                             18630          18630           0          5.4         186.3       0.1X
+before 1900, rebase off                           16188          16188           0          6.2         161.9       0.2X
+before 1900, rebase on                            19420          19420           0          5.1         194.2       0.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load timestamps from parquet:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off, rebase off                   14995          15047          47          6.7         150.0       1.0X
-after 1582, vec off, rebase on                    18111          18146          37          5.5         181.1       0.8X
-after 1582, vec on, rebase off                     4837           4873          44         20.7          48.4       3.1X
-after 1582, vec on, rebase on                      9542           9669         111         10.5          95.4       1.6X
-before 1582, vec off, rebase off                  14993          15090          94          6.7         149.9       1.0X
-before 1582, vec off, rebase on                   18675          18712          64          5.4         186.7       0.8X
-before 1582, vec on, rebase off                    4908           4923          15         20.4          49.1       3.1X
-before 1582, vec on, rebase on                    10128          10148          19          9.9         101.3       1.5X
+after 1900, vec off, rebase off                   15144          15207          67          6.6         151.4       1.0X
+after 1900, vec off, rebase on                    18223          18334          98          5.5         182.2       0.8X
+after 1900, vec on, rebase off                     4871           4894          21         20.5          48.7       3.1X
+after 1900, vec on, rebase on                      5354           5362          10         18.7          53.5       2.8X
+before 1900, vec off, rebase off                  15088          15191         147          6.6         150.9       1.0X
+before 1900, vec off, rebase on                   18623          18688          64          5.4         186.2       0.8X
+before 1900, vec on, rebase off                    4870           4885          15         20.5          48.7       3.1X
+before 1900, vec on, rebase on                     9141           9286         132         10.9          91.4       1.7X
 
 
 ================================================================================================
 Rebasing dates/timestamps in ORC datasource
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save dates to ORC:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                  23977          23977           0          4.2         239.8       1.0X
-before 1582, noop                                 10094          10094           0          9.9         100.9       2.4X
-after 1582                                        33115          33115           0          3.0         331.2       0.7X
-before 1582                                       19430          19430           0          5.1         194.3       1.2X
+after 1582, noop                                  23275          23275           0          4.3         232.8       1.0X
+before 1582, noop                                 10491          10491           0          9.5         104.9       2.2X
+after 1582                                        31821          31821           0          3.1         318.2       0.7X
+before 1582                                       19826          19826           0          5.0         198.3       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load dates from ORC:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off                               10217          10241          21          9.8         102.2       1.0X
-after 1582, vec on                                 3671           3691          31         27.2          36.7       2.8X
-before 1582, vec off                              10800          10874         114          9.3         108.0       0.9X
-before 1582, vec on                                4118           4165          74         24.3          41.2       2.5X
+after 1582, vec off                               10937          10957          22          9.1         109.4       1.0X
+after 1582, vec on                                 3728           3740          11         26.8          37.3       2.9X
+before 1582, vec off                              11445          11454           7          8.7         114.5       1.0X
+before 1582, vec on                                4096           4121          24         24.4          41.0       2.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Save timestamps to ORC:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, noop                                   2691           2691           0         37.2          26.9       1.0X
-before 1582, noop                                  2743           2743           0         36.5          27.4       1.0X
-after 1582                                        21409          21409           0          4.7         214.1       0.1X
-before 1582                                       22554          22554           0          4.4         225.5       0.1X
+after 1900, noop                                   2849           2849           0         35.1          28.5       1.0X
+before 1900, noop                                  2828           2828           0         35.4          28.3       1.0X
+after 1900                                        20289          20289           0          4.9         202.9       0.1X
+before 1900                                       20929          20929           0          4.8         209.3       0.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08 on Linux 4.15.0-1063-aws
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Load timestamps from ORC:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-after 1582, vec off                               14752          14855         103          6.8         147.5       1.0X
-after 1582, vec on                                 8146           8185          34         12.3          81.5       1.8X
-before 1582, vec off                              15247          15294          46          6.6         152.5       1.0X
-before 1582, vec on                                8414           8466          52         11.9          84.1       1.8X
+after 1900, vec off                               15095          15160          63          6.6         151.0       1.0X
+after 1900, vec on                                 7834           7866          28         12.8          78.3       1.9X
+before 1900, vec off                              15631          15656          22          6.4         156.3       1.0X
+before 1900, vec on                                8305           8342          44         12.0          83.0       1.8X
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The results are generated on

| Item | Description |
| ---- | ----|
| Region | us-west-2 (Oregon) |
| Instance | r3.xlarge |
| AMI | ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190722.1 (ami-06f2f779464715dc5) |
| Java | OpenJDK 64-Bit Server VM 1.8.0_242 and OpenJDK 64-Bit Server VM 11.0.6+10 |

## How was this patch tested?

By running the benchmark via:
```
SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain org.apache.spark.sql.execution.benchmark.DateTimeRebaseBenchmark"
```