### PR TITLE
Re-gen date-time benchmarks

### DIFF
--- a/sql/core/benchmarks/CSVBenchmark-results.txt
+++ b/sql/core/benchmarks/CSVBenchmark-results.txt
@@ -2,66 +2,66 @@
 Benchmark to measure CSV read/write performance
 ================================================================================================
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Parsing quoted values:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-One quoted string                                 24073          24109          33          0.0      481463.5       1.0X
+One quoted string                                 50365          50545         181          0.0     1007301.7       1.0X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Wide rows with 1000 columns:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 1000 columns                               58415          59611        2071          0.0       58414.8       1.0X
-Select 100 columns                                22568          23020         594          0.0       22568.0       2.6X
-Select one column                                 18995          19058          99          0.1       18995.0       3.1X
-count()                                            5301           5332          30          0.2        5300.9      11.0X
-Select 100 columns, one bad input field           39736          40153         361          0.0       39736.1       1.5X
-Select 100 columns, corrupt record field          47195          47826         590          0.0       47195.2       1.2X
+Select 1000 columns                              129858         130769        1301          0.0      129858.1       1.0X
+Select 100 columns                                43649          43745          84          0.0       43649.5       3.0X
+Select one column                                 36793          36916         112          0.0       36793.0       3.5X
+count()                                           11083          11104          21          0.1       11083.5      11.7X
+Select 100 columns, one bad input field           95846          96170         281          0.0       95845.8       1.4X
+Select 100 columns, corrupt record field         116239         116548         331          0.0      116238.7       1.1X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Count a dataset with 10 columns:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns + count()                        9884           9904          25          1.0         988.4       1.0X
-Select 1 column + count()                          6794           6835          46          1.5         679.4       1.5X
-count()                                            2060           2065           5          4.9         206.0       4.8X
+Select 10 columns + count()                       20952          21014          93          0.5        2095.2       1.0X
+Select 1 column + count()                         14359          14409          50          0.7        1435.9       1.5X
+count()                                            3821           3836          15          2.6         382.1       5.5X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      717            732          18         14.0          71.7       1.0X
-to_csv(timestamp)                                  6994           7100         121          1.4         699.4       0.1X
-write timestamps to files                          6417           6435          27          1.6         641.7       0.1X
-Create a dataset of dates                           827            855          24         12.1          82.7       0.9X
-to_csv(date)                                       4408           4438          32          2.3         440.8       0.2X
-write dates to files                               3738           3758          28          2.7         373.8       0.2X
+Create a dataset of timestamps                     1961           1976          14          5.1         196.1       1.0X
+to_csv(timestamp)                                 14411          14846         539          0.7        1441.1       0.1X
+write timestamps to files                         12874          12979         128          0.8        1287.4       0.2X
+Create a dataset of dates                          2183           2199          18          4.6         218.3       0.9X
+to_csv(date)                                       8638           8670          42          1.2         863.8       0.2X
+write dates to files                               6943           6952           9          1.4         694.3       0.3X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Read dates and timestamps:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                     1121           1176          52          8.9         112.1       1.0X
-read timestamps from files                        21298          21366         105          0.5        2129.8       0.1X
-infer timestamps from files                       41008          41051          39          0.2        4100.8       0.0X
-read date text from files                           962            967           5         10.4          96.2       1.2X
-read date from files                              11749          11772          22          0.9        1174.9       0.1X
-infer date from files                             12426          12459          29          0.8        1242.6       0.1X
-timestamp strings                                  1508           1519           9          6.6         150.8       0.7X
-parse timestamps from Dataset[String]             21674          21997         455          0.5        2167.4       0.1X
-infer timestamps from Dataset[String]             42141          42230         105          0.2        4214.1       0.0X
-date strings                                       1694           1701           8          5.9         169.4       0.7X
-parse dates from Dataset[String]                  12929          12951          25          0.8        1292.9       0.1X
-from_csv(timestamp)                               20603          20786         166          0.5        2060.3       0.1X
-from_csv(date)                                    12325          12338          12          0.8        1232.5       0.1X
+read timestamp text from files                     2239           2242           5          4.5         223.9       1.0X
+read timestamps from files                        64486          64664         162          0.2        6448.6       0.0X
+infer timestamps from files                      120125         120694         700          0.1       12012.5       0.0X
+read date text from files                          1960           1962           3          5.1         196.0       1.1X
+read date from files                              28291          28365          66          0.4        2829.1       0.1X
+infer date from files                             28653          28707          74          0.3        2865.3       0.1X
+timestamp strings                                  3719           3731          17          2.7         371.9       0.6X
+parse timestamps from Dataset[String]             75005          75363         521          0.1        7500.5       0.0X
+infer timestamps from Dataset[String]            146329         147061         634          0.1       14632.9       0.0X
+date strings                                       3732           3744          11          2.7         373.2       0.6X
+parse dates from Dataset[String]                  33797          33966         279          0.3        3379.7       0.1X
+from_csv(timestamp)                               74924          75170         301          0.1        7492.4       0.0X
+from_csv(date)                                    31235          31387         133          0.3        3123.5       0.1X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
+Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                       12455          12474          22          0.0      124553.8       1.0X
-pushdown disabled                                 12462          12486          29          0.0      124624.9       1.0X
-w/ filters                                         1073           1092          18          0.1       10727.6      11.6X
+w/o filters                                       33160          33216          53          0.0      331598.7       1.0X
+pushdown disabled                                 33335          33364          42          0.0      333353.6       1.0X
+w/ filters                                         1873           1877           4          0.1       18726.0      17.7X
 
 

--- a/sql/core/benchmarks/CSVBenchmark-results.txt
+++ b/sql/core/benchmarks/CSVBenchmark-results.txt
@@ -2,66 +2,66 @@
 Benchmark to measure CSV read/write performance
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Parsing quoted values:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-One quoted string                                 50365          50545         181          0.0     1007301.7       1.0X
+One quoted string                                 24073          24109          33          0.0      481463.5       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Wide rows with 1000 columns:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 1000 columns                              129858         130769        1301          0.0      129858.1       1.0X
-Select 100 columns                                43649          43745          84          0.0       43649.5       3.0X
-Select one column                                 36793          36916         112          0.0       36793.0       3.5X
-count()                                           11083          11104          21          0.1       11083.5      11.7X
-Select 100 columns, one bad input field           95846          96170         281          0.0       95845.8       1.4X
-Select 100 columns, corrupt record field         116239         116548         331          0.0      116238.7       1.1X
+Select 1000 columns                               58415          59611        2071          0.0       58414.8       1.0X
+Select 100 columns                                22568          23020         594          0.0       22568.0       2.6X
+Select one column                                 18995          19058          99          0.1       18995.0       3.1X
+count()                                            5301           5332          30          0.2        5300.9      11.0X
+Select 100 columns, one bad input field           39736          40153         361          0.0       39736.1       1.5X
+Select 100 columns, corrupt record field          47195          47826         590          0.0       47195.2       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Count a dataset with 10 columns:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns + count()                       20952          21014          93          0.5        2095.2       1.0X
-Select 1 column + count()                         14359          14409          50          0.7        1435.9       1.5X
-count()                                            3821           3836          15          2.6         382.1       5.5X
+Select 10 columns + count()                        9884           9904          25          1.0         988.4       1.0X
+Select 1 column + count()                          6794           6835          46          1.5         679.4       1.5X
+count()                                            2060           2065           5          4.9         206.0       4.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                     1961           1976          14          5.1         196.1       1.0X
-to_csv(timestamp)                                 14411          14846         539          0.7        1441.1       0.1X
-write timestamps to files                         12874          12979         128          0.8        1287.4       0.2X
-Create a dataset of dates                          2183           2199          18          4.6         218.3       0.9X
-to_csv(date)                                       8638           8670          42          1.2         863.8       0.2X
-write dates to files                               6943           6952           9          1.4         694.3       0.3X
+Create a dataset of timestamps                      717            732          18         14.0          71.7       1.0X
+to_csv(timestamp)                                  6994           7100         121          1.4         699.4       0.1X
+write timestamps to files                          6417           6435          27          1.6         641.7       0.1X
+Create a dataset of dates                           827            855          24         12.1          82.7       0.9X
+to_csv(date)                                       4408           4438          32          2.3         440.8       0.2X
+write dates to files                               3738           3758          28          2.7         373.8       0.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Read dates and timestamps:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                     2239           2242           5          4.5         223.9       1.0X
-read timestamps from files                        64486          64664         162          0.2        6448.6       0.0X
-infer timestamps from files                      120125         120694         700          0.1       12012.5       0.0X
-read date text from files                          1960           1962           3          5.1         196.0       1.1X
-read date from files                              28291          28365          66          0.4        2829.1       0.1X
-infer date from files                             28653          28707          74          0.3        2865.3       0.1X
-timestamp strings                                  3719           3731          17          2.7         371.9       0.6X
-parse timestamps from Dataset[String]             75005          75363         521          0.1        7500.5       0.0X
-infer timestamps from Dataset[String]            146329         147061         634          0.1       14632.9       0.0X
-date strings                                       3732           3744          11          2.7         373.2       0.6X
-parse dates from Dataset[String]                  33797          33966         279          0.3        3379.7       0.1X
-from_csv(timestamp)                               74924          75170         301          0.1        7492.4       0.0X
-from_csv(date)                                    31235          31387         133          0.3        3123.5       0.1X
+read timestamp text from files                     1121           1176          52          8.9         112.1       1.0X
+read timestamps from files                        21298          21366         105          0.5        2129.8       0.1X
+infer timestamps from files                       41008          41051          39          0.2        4100.8       0.0X
+read date text from files                           962            967           5         10.4          96.2       1.2X
+read date from files                              11749          11772          22          0.9        1174.9       0.1X
+infer date from files                             12426          12459          29          0.8        1242.6       0.1X
+timestamp strings                                  1508           1519           9          6.6         150.8       0.7X
+parse timestamps from Dataset[String]             21674          21997         455          0.5        2167.4       0.1X
+infer timestamps from Dataset[String]             42141          42230         105          0.2        4214.1       0.0X
+date strings                                       1694           1701           8          5.9         169.4       0.7X
+parse dates from Dataset[String]                  12929          12951          25          0.8        1292.9       0.1X
+from_csv(timestamp)                               20603          20786         166          0.5        2060.3       0.1X
+from_csv(date)                                    12325          12338          12          0.8        1232.5       0.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
-Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_231-b11 on Mac OS X 10.15.4
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                       33160          33216          53          0.0      331598.7       1.0X
-pushdown disabled                                 33335          33364          42          0.0      333353.6       1.0X
-w/ filters                                         1873           1877           4          0.1       18726.0      17.7X
+w/o filters                                       12455          12474          22          0.0      124553.8       1.0X
+pushdown disabled                                 12462          12486          29          0.0      124624.9       1.0X
+w/ filters                                         1073           1092          18          0.1       10727.6      11.6X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -6,18 +6,18 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                 1638           1701          89          6.1         163.8       1.0X
-date + interval(m, d)                              1785           1790           7          5.6         178.5       0.9X
-date + interval(m, d, ms)                          6229           6270          58          1.6         622.9       0.3X
-date - interval(m)                                 1500           1503           4          6.7         150.0       1.1X
-date - interval(m, d)                              1764           1766           3          5.7         176.4       0.9X
-date - interval(m, d, ms)                          6428           6446          25          1.6         642.8       0.3X
-timestamp + interval(m)                            2719           2722           4          3.7         271.9       0.6X
-timestamp + interval(m, d)                         3011           3021          14          3.3         301.1       0.5X
-timestamp + interval(m, d, ms)                     3405           3412           9          2.9         340.5       0.5X
-timestamp - interval(m)                            2759           2764           7          3.6         275.9       0.6X
-timestamp - interval(m, d)                         3094           3112          25          3.2         309.4       0.5X
-timestamp - interval(m, d, ms)                     3388           3392           5          3.0         338.8       0.5X
+date + interval(m)                                 1562           1598          50          6.4         156.2       1.0X
+date + interval(m, d)                              1709           1758          69          5.9         170.9       0.9X
+date + interval(m, d, ms)                          5320           5324           6          1.9         532.0       0.3X
+date - interval(m)                                 1417           1421           5          7.1         141.7       1.1X
+date - interval(m, d)                              1663           1674          16          6.0         166.3       0.9X
+date - interval(m, d, ms)                          5535           5553          27          1.8         553.5       0.3X
+timestamp + interval(m)                            3013           3017           5          3.3         301.3       0.5X
+timestamp + interval(m, d)                         3388           3391           5          3.0         338.8       0.5X
+timestamp + interval(m, d, ms)                     3419           3560         200          2.9         341.9       0.5X
+timestamp - interval(m)                            2990           3000          14          3.3         299.0       0.5X
+timestamp - interval(m, d)                         3113           3248         192          3.2         311.3       0.5X
+timestamp - interval(m, d, ms)                     3420           3425           8          2.9         342.0       0.5X
 
 
 ================================================================================================
@@ -28,92 +28,92 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    319            323           6         31.4          31.9       1.0X
-cast to timestamp wholestage on                     304            311           8         32.9          30.4       1.0X
+cast to timestamp wholestage off                    321            321           0         31.1          32.1       1.0X
+cast to timestamp wholestage on                     302            323          19         33.1          30.2       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                   1234           1239           6          8.1         123.4       1.0X
-year of timestamp wholestage on                    1229           1244          22          8.1         122.9       1.0X
+year of timestamp wholestage off                   1226           1226           0          8.2         122.6       1.0X
+year of timestamp wholestage on                    1196           1209          14          8.4         119.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                1440           1445           7          6.9         144.0       1.0X
-quarter of timestamp wholestage on                 1358           1361           3          7.4         135.8       1.1X
+quarter of timestamp wholestage off                1432           1439           9          7.0         143.2       1.0X
+quarter of timestamp wholestage on                 1338           1348           8          7.5         133.8       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                  1239           1240           1          8.1         123.9       1.0X
-month of timestamp wholestage on                   1221           1239          26          8.2         122.1       1.0X
+month of timestamp wholestage off                  1215           1217           2          8.2         121.5       1.0X
+month of timestamp wholestage on                   1192           1204          17          8.4         119.2       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1926           1934          11          5.2         192.6       1.0X
-weekofyear of timestamp wholestage on              1901           1911          10          5.3         190.1       1.0X
+weekofyear of timestamp wholestage off             2103           2119          23          4.8         210.3       1.0X
+weekofyear of timestamp wholestage on              1824           1828           4          5.5         182.4       1.2X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                    1225           1229           6          8.2         122.5       1.0X
-day of timestamp wholestage on                     1217           1225           7          8.2         121.7       1.0X
+day of timestamp wholestage off                    1210           1214           5          8.3         121.0       1.0X
+day of timestamp wholestage on                     1192           1195           4          8.4         119.2       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off              1290           1295           7          7.8         129.0       1.0X
-dayofyear of timestamp wholestage on               1262           1270           7          7.9         126.2       1.0X
+dayofyear of timestamp wholestage off              1268           1277          12          7.9         126.8       1.0X
+dayofyear of timestamp wholestage on               1244           1250           7          8.0         124.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off             1239           1239           1          8.1         123.9       1.0X
-dayofmonth of timestamp wholestage on              1215           1222           8          8.2         121.5       1.0X
+dayofmonth of timestamp wholestage off             1241           1252          16          8.1         124.1       1.0X
+dayofmonth of timestamp wholestage on              1192           1195           3          8.4         119.2       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off              1421           1422           2          7.0         142.1       1.0X
-dayofweek of timestamp wholestage on               1379           1388           8          7.3         137.9       1.0X
+dayofweek of timestamp wholestage off              1410           1428          25          7.1         141.0       1.0X
+dayofweek of timestamp wholestage on               1351           1363          13          7.4         135.1       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                1349           1351           2          7.4         134.9       1.0X
-weekday of timestamp wholestage on                 1320           1327           8          7.6         132.0       1.0X
+weekday of timestamp wholestage off                1345           1353          11          7.4         134.5       1.0X
+weekday of timestamp wholestage on                 1292           1300           5          7.7         129.2       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                   1024           1024           0          9.8         102.4       1.0X
-hour of timestamp wholestage on                     921            929          11         10.9          92.1       1.1X
+hour of timestamp wholestage off                   1005           1007           3         10.0         100.5       1.0X
+hour of timestamp wholestage on                     933            941          10         10.7          93.3       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  977            982           6         10.2          97.7       1.0X
-minute of timestamp wholestage on                   927            929           2         10.8          92.7       1.1X
+minute of timestamp wholestage off                  970            975           6         10.3          97.0       1.0X
+minute of timestamp wholestage on                   934            936           2         10.7          93.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  987            989           3         10.1          98.7       1.0X
-second of timestamp wholestage on                   923            926           5         10.8          92.3       1.1X
+second of timestamp wholestage off                 1004           1011           9         10.0         100.4       1.0X
+second of timestamp wholestage on                   932            940           6         10.7          93.2       1.1X
 
 
 ================================================================================================
@@ -124,15 +124,15 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         303            311          12         33.0          30.3       1.0X
-current_date wholestage on                          266            271           5         37.5          26.6       1.1X
+current_date wholestage off                         292            296           6         34.2          29.2       1.0X
+current_date wholestage on                          264            277          16         37.9          26.4       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    297            297           1         33.7          29.7       1.0X
-current_timestamp wholestage on                     264            272           7         37.8          26.4       1.1X
+current_timestamp wholestage off                    296            296           0         33.8          29.6       1.0X
+current_timestamp wholestage on                     256            276          27         39.1          25.6       1.2X
 
 
 ================================================================================================
@@ -143,43 +143,43 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                        1062           1063           2          9.4         106.2       1.0X
-cast to date wholestage on                         1007           1021          20          9.9         100.7       1.1X
+cast to date wholestage off                        1046           1048           2          9.6         104.6       1.0X
+cast to date wholestage on                          986            991           5         10.1          98.6       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                            1262           1265           5          7.9         126.2       1.0X
-last_day wholestage on                             1244           1256          14          8.0         124.4       1.0X
+last_day wholestage off                            1259           1262           4          7.9         125.9       1.0X
+last_day wholestage on                             1226           1240          12          8.2         122.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                            1119           1121           2          8.9         111.9       1.0X
-next_day wholestage on                             1057           1063           6          9.5         105.7       1.1X
+next_day wholestage off                            1114           1117           3          9.0         111.4       1.0X
+next_day wholestage on                             1036           1041           7          9.7         103.6       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                            1054           1059           7          9.5         105.4       1.0X
-date_add wholestage on                             1037           1069          52          9.6         103.7       1.0X
+date_add wholestage off                            1047           1048           1          9.6         104.7       1.0X
+date_add wholestage on                             1015           1022          11          9.8         101.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                            1054           1056           4          9.5         105.4       1.0X
-date_sub wholestage on                             1036           1040           4          9.7         103.6       1.0X
+date_sub wholestage off                            1044           1069          36          9.6         104.4       1.0X
+date_sub wholestage on                             1016           1018           1          9.8         101.6       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                          1408           1421          19          7.1         140.8       1.0X
-add_months wholestage on                           1434           1440           7          7.0         143.4       1.0X
+add_months wholestage off                          1367           1367           0          7.3         136.7       1.0X
+add_months wholestage on                           1392           1401           8          7.2         139.2       1.0X
 
 
 ================================================================================================
@@ -190,8 +190,8 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         5937           6169         328          1.7         593.7       1.0X
-format date wholestage on                          5836           5878          74          1.7         583.6       1.0X
+format date wholestage off                         5530           5776         348          1.8         553.0       1.0X
+format date wholestage on                          5722           5752          23          1.7         572.2       1.0X
 
 
 ================================================================================================
@@ -202,8 +202,8 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       8904           8914          14          1.1         890.4       1.0X
-from_unixtime wholestage on                        8918           8936          13          1.1         891.8       1.0X
+from_unixtime wholestage off                       8614           8624          14          1.2         861.4       1.0X
+from_unixtime wholestage on                        8513           8531          14          1.2         851.3       1.0X
 
 
 ================================================================================================
@@ -214,15 +214,15 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                  1110           1112           3          9.0         111.0       1.0X
-from_utc_timestamp wholestage on                   1115           1119           3          9.0         111.5       1.0X
+from_utc_timestamp wholestage off                  1106           1107           1          9.0         110.6       1.0X
+from_utc_timestamp wholestage on                   1082           1086           4          9.2         108.2       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1524           1525           1          6.6         152.4       1.0X
-to_utc_timestamp wholestage on                     1450           1458          14          6.9         145.0       1.1X
+to_utc_timestamp wholestage off                    1522           1525           4          6.6         152.2       1.0X
+to_utc_timestamp wholestage on                     1444           1450           4          6.9         144.4       1.1X
 
 
 ================================================================================================
@@ -233,29 +233,29 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        341            342           1         29.3          34.1       1.0X
-cast interval wholestage on                         285            294           7         35.1          28.5       1.2X
+cast interval wholestage off                        334            335           1         29.9          33.4       1.0X
+cast interval wholestage on                         281            294          15         35.6          28.1       1.2X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1874           1881          10          5.3         187.4       1.0X
-datediff wholestage on                             1785           1791           3          5.6         178.5       1.0X
+datediff wholestage off                            1826           1840          19          5.5         182.6       1.0X
+datediff wholestage on                             1738           1739           1          5.8         173.8       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      5038           5042           5          2.0         503.8       1.0X
-months_between wholestage on                       4979           4987           8          2.0         497.9       1.0X
+months_between wholestage off                      4966           4974          12          2.0         496.6       1.0X
+months_between wholestage on                       4944           4948           6          2.0         494.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                              1716           1841         177          0.6        1716.2       1.0X
-window wholestage on                              46024          46063          27          0.0       46024.1       0.0X
+window wholestage off                              1809           1909         140          0.6        1809.4       1.0X
+window wholestage on                              46291          46333          32          0.0       46290.7       0.0X
 
 
 ================================================================================================
@@ -266,134 +266,134 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     2428           2429           2          4.1         242.8       1.0X
-date_trunc YEAR wholestage on                      2451           2469          12          4.1         245.1       1.0X
+date_trunc YEAR wholestage off                     2514           2523          12          4.0         251.4       1.0X
+date_trunc YEAR wholestage on                      2438           2450           9          4.1         243.8       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     2423           2426           3          4.1         242.3       1.0X
-date_trunc YYYY wholestage on                      2454           2462           8          4.1         245.4       1.0X
+date_trunc YYYY wholestage off                     2517           2521           6          4.0         251.7       1.0X
+date_trunc YYYY wholestage on                      2431           2441           7          4.1         243.1       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       2421           2441          28          4.1         242.1       1.0X
-date_trunc YY wholestage on                        2453           2461           9          4.1         245.3       1.0X
+date_trunc YY wholestage off                       2499           2515          22          4.0         249.9       1.0X
+date_trunc YY wholestage on                        2428           2437           7          4.1         242.8       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      2425           2427           3          4.1         242.5       1.0X
-date_trunc MON wholestage on                       2431           2438           9          4.1         243.1       1.0X
+date_trunc MON wholestage off                      2503           2524          29          4.0         250.3       1.0X
+date_trunc MON wholestage on                       2428           2438          14          4.1         242.8       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    2427           2433           8          4.1         242.7       1.0X
-date_trunc MONTH wholestage on                     2429           2435           4          4.1         242.9       1.0X
+date_trunc MONTH wholestage off                    2502           2503           1          4.0         250.2       1.0X
+date_trunc MONTH wholestage on                     2425           2432           8          4.1         242.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       2425           2431           9          4.1         242.5       1.0X
-date_trunc MM wholestage on                        2430           2435           4          4.1         243.0       1.0X
+date_trunc MM wholestage off                       2489           2499          14          4.0         248.9       1.0X
+date_trunc MM wholestage on                        2428           2437          10          4.1         242.8       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      2117           2119           4          4.7         211.7       1.0X
-date_trunc DAY wholestage on                       2036           2118         174          4.9         203.6       1.0X
+date_trunc DAY wholestage off                      2148           2167          26          4.7         214.8       1.0X
+date_trunc DAY wholestage on                       2048           2057           8          4.9         204.8       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       2116           2119           5          4.7         211.6       1.0X
-date_trunc DD wholestage on                        2035           2043          10          4.9         203.5       1.0X
+date_trunc DD wholestage off                       2147           2151           5          4.7         214.7       1.0X
+date_trunc DD wholestage on                        2050           2051           1          4.9         205.0       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     2013           2014           2          5.0         201.3       1.0X
-date_trunc HOUR wholestage on                      2077           2088          13          4.8         207.7       1.0X
+date_trunc HOUR wholestage off                     2123           2134          16          4.7         212.3       1.0X
+date_trunc HOUR wholestage on                      2059           2066           5          4.9         205.9       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    363            368           8         27.6          36.3       1.0X
-date_trunc MINUTE wholestage on                     321            326           7         31.2          32.1       1.1X
+date_trunc MINUTE wholestage off                    377            377           0         26.6          37.7       1.0X
+date_trunc MINUTE wholestage on                     349            354           7         28.7          34.9       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    365            366           0         27.4          36.5       1.0X
-date_trunc SECOND wholestage on                     319            332          16         31.4          31.9       1.1X
+date_trunc SECOND wholestage off                    379            380           1         26.4          37.9       1.0X
+date_trunc SECOND wholestage on                     345            349           3         29.0          34.5       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     2371           2376           7          4.2         237.1       1.0X
-date_trunc WEEK wholestage on                      2314           2322           8          4.3         231.4       1.0X
+date_trunc WEEK wholestage off                     2418           2420           3          4.1         241.8       1.0X
+date_trunc WEEK wholestage on                      2373           2394          19          4.2         237.3       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  3334           3335           1          3.0         333.4       1.0X
-date_trunc QUARTER wholestage on                   3286           3291           7          3.0         328.6       1.0X
+date_trunc QUARTER wholestage off                  3262           3263           1          3.1         326.2       1.0X
+date_trunc QUARTER wholestage on                   3214           3222          15          3.1         321.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           303            304           2         33.0          30.3       1.0X
-trunc year wholestage on                            283            291           5         35.3          28.3       1.1X
+trunc year wholestage off                           348            369          29         28.7          34.8       1.0X
+trunc year wholestage on                            524            529           5         19.1          52.4       0.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           324            330           8         30.9          32.4       1.0X
-trunc yyyy wholestage on                            283            291           9         35.3          28.3       1.1X
+trunc yyyy wholestage off                           346            367          29         28.9          34.6       1.0X
+trunc yyyy wholestage on                            348            487          78         28.7          34.8       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             304            305           3         32.9          30.4       1.0X
-trunc yy wholestage on                              283            302          28         35.3          28.3       1.1X
+trunc yy wholestage off                             349            355           9         28.7          34.9       1.0X
+trunc yy wholestage on                              471            507          21         21.2          47.1       0.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            315            319           6         31.7          31.5       1.0X
-trunc mon wholestage on                             284            287           5         35.3          28.4       1.1X
+trunc mon wholestage off                            346            355          12         28.9          34.6       1.0X
+trunc mon wholestage on                             376            457          72         26.6          37.6       0.9X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          305            314          13         32.8          30.5       1.0X
-trunc month wholestage on                           283            292          14         35.3          28.3       1.1X
+trunc month wholestage off                          351            354           5         28.5          35.1       1.0X
+trunc month wholestage on                           414            499          48         24.2          41.4       0.8X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             301            301           0         33.2          30.1       1.0X
-trunc mm wholestage on                              285            290           7         35.1          28.5       1.1X
+trunc mm wholestage off                             345            345           1         29.0          34.5       1.0X
+trunc mm wholestage on                              464            509          25         21.6          46.4       0.7X
 
 
 ================================================================================================
@@ -404,36 +404,36 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     218            220           3          4.6         218.4       1.0X
-to timestamp str wholestage on                      213            216           6          4.7         212.5       1.0X
+to timestamp str wholestage off                     227            228           1          4.4         227.2       1.0X
+to timestamp str wholestage on                      213            215           2          4.7         213.1       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                        1838           1842           5          0.5        1838.1       1.0X
-to_timestamp wholestage on                         1952           1971          11          0.5        1952.2       0.9X
+to_timestamp wholestage off                        2678           2694          24          0.4        2677.8       1.0X
+to_timestamp wholestage on                         2491           2501          11          0.4        2490.7       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                   1987           1988           1          0.5        1986.9       1.0X
-to_unix_timestamp wholestage on                    1944           1948           3          0.5        1944.2       1.0X
+to_unix_timestamp wholestage off                   2541           2548          11          0.4        2540.7       1.0X
+to_unix_timestamp wholestage on                    2571           2581          14          0.4        2571.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          263            264           0          3.8         263.5       1.0X
-to date str wholestage on                           263            265           2          3.8         262.6       1.0X
+to date str wholestage off                          282            283           2          3.5         282.3       1.0X
+to date str wholestage on                           266            267           2          3.8         265.9       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                             3560           3567          11          0.3        3559.7       1.0X
-to_date wholestage on                              3525           3534          10          0.3        3524.8       1.0X
+to_date wholestage off                             3902           3953          71          0.3        3902.4       1.0X
+to_date wholestage on                              3826           3838           9          0.3        3826.5       1.0X
 
 
 ================================================================================================
@@ -444,14 +444,14 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  405            416          16         12.3          81.0       1.0X
-From java.time.LocalDate                            344            352          14         14.5          68.8       1.2X
-Collect java.sql.Date                              1622           2553        1372          3.1         324.4       0.2X
-Collect java.time.LocalDate                        1464           1482          20          3.4         292.8       0.3X
-From java.sql.Timestamp                             248            258          15         20.2          49.6       1.6X
-From java.time.Instant                              237            243           7         21.1          47.4       1.7X
-Collect longs                                      1252           1341         109          4.0         250.5       0.3X
-Collect java.sql.Timestamp                         1515           1516           2          3.3         302.9       0.3X
-Collect java.time.Instant                          1379           1490          96          3.6         275.8       0.3X
+From java.sql.Date                                  405            413           9         12.3          81.1       1.0X
+From java.time.LocalDate                            356            359           3         14.1          71.1       1.1X
+Collect java.sql.Date                              1661           2657        1496          3.0         332.2       0.2X
+Collect java.time.LocalDate                        1456           1480          26          3.4         291.3       0.3X
+From java.sql.Timestamp                             258            263           5         19.4          51.6       1.6X
+From java.time.Instant                              247            249           2         20.2          49.4       1.6X
+Collect longs                                      1283           1363          84          3.9         256.6       0.3X
+Collect java.sql.Timestamp                         1462           1492          30          3.4         292.4       0.3X
+Collect java.time.Instant                          1326           1438          97          3.8         265.2       0.3X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -6,18 +6,18 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                 1562           1598          50          6.4         156.2       1.0X
-date + interval(m, d)                              1709           1758          69          5.9         170.9       0.9X
-date + interval(m, d, ms)                          5320           5324           6          1.9         532.0       0.3X
-date - interval(m)                                 1417           1421           5          7.1         141.7       1.1X
-date - interval(m, d)                              1663           1674          16          6.0         166.3       0.9X
-date - interval(m, d, ms)                          5535           5553          27          1.8         553.5       0.3X
-timestamp + interval(m)                            3013           3017           5          3.3         301.3       0.5X
-timestamp + interval(m, d)                         3388           3391           5          3.0         338.8       0.5X
-timestamp + interval(m, d, ms)                     3419           3560         200          2.9         341.9       0.5X
-timestamp - interval(m)                            2990           3000          14          3.3         299.0       0.5X
-timestamp - interval(m, d)                         3113           3248         192          3.2         311.3       0.5X
-timestamp - interval(m, d, ms)                     3420           3425           8          2.9         342.0       0.5X
+date + interval(m)                                 1557           1616          83          6.4         155.7       1.0X
+date + interval(m, d)                              1772           1786          20          5.6         177.2       0.9X
+date + interval(m, d, ms)                          6122           6136          20          1.6         612.2       0.3X
+date - interval(m)                                 1467           1471           6          6.8         146.7       1.1X
+date - interval(m, d)                              1729           1735           9          5.8         172.9       0.9X
+date - interval(m, d, ms)                          6271           6306          49          1.6         627.1       0.2X
+timestamp + interval(m)                            3282           3392         155          3.0         328.2       0.5X
+timestamp + interval(m, d)                         3630           3635           7          2.8         363.0       0.4X
+timestamp + interval(m, d, ms)                     3987           3989           3          2.5         398.7       0.4X
+timestamp - interval(m)                            3278           3280           3          3.1         327.8       0.5X
+timestamp - interval(m, d)                         3643           3647           6          2.7         364.3       0.4X
+timestamp - interval(m, d, ms)                     3962           3963           2          2.5         396.2       0.4X
 
 
 ================================================================================================
@@ -28,92 +28,92 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    321            321           0         31.1          32.1       1.0X
-cast to timestamp wholestage on                     302            323          19         33.1          30.2       1.1X
+cast to timestamp wholestage off                    320            322           2         31.2          32.0       1.0X
+cast to timestamp wholestage on                     295            306          19         33.8          29.5       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                   1226           1226           0          8.2         122.6       1.0X
-year of timestamp wholestage on                    1196           1209          14          8.4         119.6       1.0X
+year of timestamp wholestage off                   1211           1218           9          8.3         121.1       1.0X
+year of timestamp wholestage on                    1202           1210           6          8.3         120.2       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                1432           1439           9          7.0         143.2       1.0X
-quarter of timestamp wholestage on                 1338           1348           8          7.5         133.8       1.1X
+quarter of timestamp wholestage off                1420           1420           0          7.0         142.0       1.0X
+quarter of timestamp wholestage on                 1341           1346           4          7.5         134.1       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                  1215           1217           2          8.2         121.5       1.0X
-month of timestamp wholestage on                   1192           1204          17          8.4         119.2       1.0X
+month of timestamp wholestage off                  1225           1235          14          8.2         122.5       1.0X
+month of timestamp wholestage on                   1194           1202          10          8.4         119.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             2103           2119          23          4.8         210.3       1.0X
-weekofyear of timestamp wholestage on              1824           1828           4          5.5         182.4       1.2X
+weekofyear of timestamp wholestage off             1814           1814           1          5.5         181.4       1.0X
+weekofyear of timestamp wholestage on              1827           1839          11          5.5         182.7       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                    1210           1214           5          8.3         121.0       1.0X
-day of timestamp wholestage on                     1192           1195           4          8.4         119.2       1.0X
+day of timestamp wholestage off                    1210           1212           4          8.3         121.0       1.0X
+day of timestamp wholestage on                     1189           1192           3          8.4         118.9       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off              1268           1277          12          7.9         126.8       1.0X
-dayofyear of timestamp wholestage on               1244           1250           7          8.0         124.4       1.0X
+dayofyear of timestamp wholestage off              1270           1275           8          7.9         127.0       1.0X
+dayofyear of timestamp wholestage on               1238           1245           8          8.1         123.8       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off             1241           1252          16          8.1         124.1       1.0X
-dayofmonth of timestamp wholestage on              1192           1195           3          8.4         119.2       1.0X
+dayofmonth of timestamp wholestage off             1227           1229           3          8.2         122.7       1.0X
+dayofmonth of timestamp wholestage on              1191           1196           6          8.4         119.1       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off              1410           1428          25          7.1         141.0       1.0X
-dayofweek of timestamp wholestage on               1351           1363          13          7.4         135.1       1.0X
+dayofweek of timestamp wholestage off              1399           1404           7          7.1         139.9       1.0X
+dayofweek of timestamp wholestage on               1353           1360          11          7.4         135.3       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                1345           1353          11          7.4         134.5       1.0X
-weekday of timestamp wholestage on                 1292           1300           5          7.7         129.2       1.0X
+weekday of timestamp wholestage off                1341           1341           0          7.5         134.1       1.0X
+weekday of timestamp wholestage on                 1290           1293           3          7.8         129.0       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                   1005           1007           3         10.0         100.5       1.0X
-hour of timestamp wholestage on                     933            941          10         10.7          93.3       1.1X
+hour of timestamp wholestage off                   1008           1008           0          9.9         100.8       1.0X
+hour of timestamp wholestage on                     931            938           6         10.7          93.1       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  970            975           6         10.3          97.0       1.0X
-minute of timestamp wholestage on                   934            936           2         10.7          93.4       1.0X
+minute of timestamp wholestage off                 1016           1019           4          9.8         101.6       1.0X
+minute of timestamp wholestage on                   933            935           2         10.7          93.3       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                 1004           1011           9         10.0         100.4       1.0X
-second of timestamp wholestage on                   932            940           6         10.7          93.2       1.1X
+second of timestamp wholestage off                  966            969           5         10.4          96.6       1.0X
+second of timestamp wholestage on                   932            938           8         10.7          93.2       1.0X
 
 
 ================================================================================================
@@ -124,15 +124,15 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         292            296           6         34.2          29.2       1.0X
-current_date wholestage on                          264            277          16         37.9          26.4       1.1X
+current_date wholestage off                         292            293           1         34.2          29.2       1.0X
+current_date wholestage on                          267            273           6         37.5          26.7       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    296            296           0         33.8          29.6       1.0X
-current_timestamp wholestage on                     256            276          27         39.1          25.6       1.2X
+current_timestamp wholestage off                    285            308          32         35.1          28.5       1.0X
+current_timestamp wholestage on                     259            332         146         38.6          25.9       1.1X
 
 
 ================================================================================================
@@ -143,43 +143,43 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                        1046           1048           2          9.6         104.6       1.0X
-cast to date wholestage on                          986            991           5         10.1          98.6       1.1X
+cast to date wholestage off                        1038           1041           5          9.6         103.8       1.0X
+cast to date wholestage on                          985           1001          18         10.2          98.5       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                            1259           1262           4          7.9         125.9       1.0X
-last_day wholestage on                             1226           1240          12          8.2         122.6       1.0X
+last_day wholestage off                            1251           1252           1          8.0         125.1       1.0X
+last_day wholestage on                             1231           1238           9          8.1         123.1       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                            1114           1117           3          9.0         111.4       1.0X
-next_day wholestage on                             1036           1041           7          9.7         103.6       1.1X
+next_day wholestage off                            1109           1109           0          9.0         110.9       1.0X
+next_day wholestage on                             1033           1037           4          9.7         103.3       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                            1047           1048           1          9.6         104.7       1.0X
-date_add wholestage on                             1015           1022          11          9.8         101.5       1.0X
+date_add wholestage off                            1041           1044           4          9.6         104.1       1.0X
+date_add wholestage on                             1018           1023           7          9.8         101.8       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                            1044           1069          36          9.6         104.4       1.0X
-date_sub wholestage on                             1016           1018           1          9.8         101.6       1.0X
+date_sub wholestage off                            1042           1045           4          9.6         104.2       1.0X
+date_sub wholestage on                             1017           1020           5          9.8         101.7       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                          1367           1367           0          7.3         136.7       1.0X
-add_months wholestage on                           1392           1401           8          7.2         139.2       1.0X
+add_months wholestage off                          1390           1395           8          7.2         139.0       1.0X
+add_months wholestage on                           1376           1382           5          7.3         137.6       1.0X
 
 
 ================================================================================================
@@ -190,8 +190,8 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         5530           5776         348          1.8         553.0       1.0X
-format date wholestage on                          5722           5752          23          1.7         572.2       1.0X
+format date wholestage off                         5804           5884         114          1.7         580.4       1.0X
+format date wholestage on                          5800           5828          29          1.7         580.0       1.0X
 
 
 ================================================================================================
@@ -202,8 +202,8 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       8614           8624          14          1.2         861.4       1.0X
-from_unixtime wholestage on                        8513           8531          14          1.2         851.3       1.0X
+from_unixtime wholestage off                       8528           8533           7          1.2         852.8       1.0X
+from_unixtime wholestage on                        8491           8502           8          1.2         849.1       1.0X
 
 
 ================================================================================================
@@ -214,15 +214,15 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                  1106           1107           1          9.0         110.6       1.0X
-from_utc_timestamp wholestage on                   1082           1086           4          9.2         108.2       1.0X
+from_utc_timestamp wholestage off                  1170           1172           2          8.5         117.0       1.0X
+from_utc_timestamp wholestage on                   1120           1127           5          8.9         112.0       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1522           1525           4          6.6         152.2       1.0X
-to_utc_timestamp wholestage on                     1444           1450           4          6.9         144.4       1.1X
+to_utc_timestamp wholestage off                    1716           1716           1          5.8         171.6       1.0X
+to_utc_timestamp wholestage on                     1661           1666           7          6.0         166.1       1.0X
 
 
 ================================================================================================
@@ -233,29 +233,29 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        334            335           1         29.9          33.4       1.0X
-cast interval wholestage on                         281            294          15         35.6          28.1       1.2X
+cast interval wholestage off                        332            335           3         30.1          33.2       1.0X
+cast interval wholestage on                         280            286           7         35.7          28.0       1.2X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1826           1840          19          5.5         182.6       1.0X
-datediff wholestage on                             1738           1739           1          5.8         173.8       1.1X
+datediff wholestage off                            1818           1831          20          5.5         181.8       1.0X
+datediff wholestage on                             1731           1739           7          5.8         173.1       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      4966           4974          12          2.0         496.6       1.0X
-months_between wholestage on                       4944           4948           6          2.0         494.4       1.0X
+months_between wholestage off                      5559           5567          11          1.8         555.9       1.0X
+months_between wholestage on                       5503           5507           3          1.8         550.3       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                              1809           1909         140          0.6        1809.4       1.0X
-window wholestage on                              46291          46333          32          0.0       46290.7       0.0X
+window wholestage off                              1767           1875         153          0.6        1767.2       1.0X
+window wholestage on                              45044          45063          12          0.0       45043.6       0.0X
 
 
 ================================================================================================
@@ -266,134 +266,134 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     2514           2523          12          4.0         251.4       1.0X
-date_trunc YEAR wholestage on                      2438           2450           9          4.1         243.8       1.0X
+date_trunc YEAR wholestage off                     2787           2793           9          3.6         278.7       1.0X
+date_trunc YEAR wholestage on                      2677           2686           8          3.7         267.7       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     2517           2521           6          4.0         251.7       1.0X
-date_trunc YYYY wholestage on                      2431           2441           7          4.1         243.1       1.0X
+date_trunc YYYY wholestage off                     2794           2795           1          3.6         279.4       1.0X
+date_trunc YYYY wholestage on                      2679           2695          14          3.7         267.9       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       2499           2515          22          4.0         249.9       1.0X
-date_trunc YY wholestage on                        2428           2437           7          4.1         242.8       1.0X
+date_trunc YY wholestage off                       2779           2780           2          3.6         277.9       1.0X
+date_trunc YY wholestage on                        2677           2678           2          3.7         267.7       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      2503           2524          29          4.0         250.3       1.0X
-date_trunc MON wholestage on                       2428           2438          14          4.1         242.8       1.0X
+date_trunc MON wholestage off                      2722           2724           3          3.7         272.2       1.0X
+date_trunc MON wholestage on                       2697           2705           8          3.7         269.7       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    2502           2503           1          4.0         250.2       1.0X
-date_trunc MONTH wholestage on                     2425           2432           8          4.1         242.5       1.0X
+date_trunc MONTH wholestage off                    2733           2735           4          3.7         273.3       1.0X
+date_trunc MONTH wholestage on                     2703           2713           9          3.7         270.3       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       2489           2499          14          4.0         248.9       1.0X
-date_trunc MM wholestage on                        2428           2437          10          4.1         242.8       1.0X
+date_trunc MM wholestage off                       2728           2728           0          3.7         272.8       1.0X
+date_trunc MM wholestage on                        2703           2708           9          3.7         270.3       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      2148           2167          26          4.7         214.8       1.0X
-date_trunc DAY wholestage on                       2048           2057           8          4.9         204.8       1.0X
+date_trunc DAY wholestage off                      2209           2215           8          4.5         220.9       1.0X
+date_trunc DAY wholestage on                       2198           2202           6          4.5         219.8       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       2147           2151           5          4.7         214.7       1.0X
-date_trunc DD wholestage on                        2050           2051           1          4.9         205.0       1.0X
+date_trunc DD wholestage off                       2208           2214           8          4.5         220.8       1.0X
+date_trunc DD wholestage on                        2194           2205          14          4.6         219.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     2123           2134          16          4.7         212.3       1.0X
-date_trunc HOUR wholestage on                      2059           2066           5          4.9         205.9       1.0X
+date_trunc HOUR wholestage off                     2228           2232           6          4.5         222.8       1.0X
+date_trunc HOUR wholestage on                      2194           2205          10          4.6         219.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    377            377           0         26.6          37.7       1.0X
-date_trunc MINUTE wholestage on                     349            354           7         28.7          34.9       1.1X
+date_trunc MINUTE wholestage off                    363            363           0         27.5          36.3       1.0X
+date_trunc MINUTE wholestage on                     330            333           4         30.3          33.0       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    379            380           1         26.4          37.9       1.0X
-date_trunc SECOND wholestage on                     345            349           3         29.0          34.5       1.1X
+date_trunc SECOND wholestage off                    362            367           8         27.6          36.2       1.0X
+date_trunc SECOND wholestage on                     331            358          52         30.2          33.1       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     2418           2420           3          4.1         241.8       1.0X
-date_trunc WEEK wholestage on                      2373           2394          19          4.2         237.3       1.0X
+date_trunc WEEK wholestage off                     2654           2667          18          3.8         265.4       1.0X
+date_trunc WEEK wholestage on                      2592           2602           8          3.9         259.2       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  3262           3263           1          3.1         326.2       1.0X
-date_trunc QUARTER wholestage on                   3214           3222          15          3.1         321.4       1.0X
+date_trunc QUARTER wholestage off                  3437           3441           6          2.9         343.7       1.0X
+date_trunc QUARTER wholestage on                   3411           3419           8          2.9         341.1       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           348            369          29         28.7          34.8       1.0X
-trunc year wholestage on                            524            529           5         19.1          52.4       0.7X
+trunc year wholestage off                           301            313          17         33.2          30.1       1.0X
+trunc year wholestage on                            305            312          12         32.8          30.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           346            367          29         28.9          34.6       1.0X
-trunc yyyy wholestage on                            348            487          78         28.7          34.8       1.0X
+trunc yyyy wholestage off                           303            305           2         33.0          30.3       1.0X
+trunc yyyy wholestage on                            299            307           6         33.5          29.9       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             349            355           9         28.7          34.9       1.0X
-trunc yy wholestage on                              471            507          21         21.2          47.1       0.7X
+trunc yy wholestage off                             302            302           0         33.1          30.2       1.0X
+trunc yy wholestage on                              304            312           7         32.9          30.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            346            355          12         28.9          34.6       1.0X
-trunc mon wholestage on                             376            457          72         26.6          37.6       0.9X
+trunc mon wholestage off                            302            303           0         33.1          30.2       1.0X
+trunc mon wholestage on                             304            313          10         32.9          30.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          351            354           5         28.5          35.1       1.0X
-trunc month wholestage on                           414            499          48         24.2          41.4       0.8X
+trunc month wholestage off                          303            305           3         33.0          30.3       1.0X
+trunc month wholestage on                           304            309           7         32.9          30.4       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             345            345           1         29.0          34.5       1.0X
-trunc mm wholestage on                              464            509          25         21.6          46.4       0.7X
+trunc mm wholestage off                             297            301           5         33.6          29.7       1.0X
+trunc mm wholestage on                              305            312           7         32.8          30.5       1.0X
 
 
 ================================================================================================
@@ -404,36 +404,36 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     227            228           1          4.4         227.2       1.0X
-to timestamp str wholestage on                      213            215           2          4.7         213.1       1.1X
+to timestamp str wholestage off                     222            226           5          4.5         222.4       1.0X
+to timestamp str wholestage on                      213            215           4          4.7         212.5       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                        2678           2694          24          0.4        2677.8       1.0X
-to_timestamp wholestage on                         2491           2501          11          0.4        2490.7       1.1X
+to_timestamp wholestage off                        1763           1765           3          0.6        1762.6       1.0X
+to_timestamp wholestage on                         1735           1747          10          0.6        1735.1       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                   2541           2548          11          0.4        2540.7       1.0X
-to_unix_timestamp wholestage on                    2571           2581          14          0.4        2571.5       1.0X
+to_unix_timestamp wholestage off                   1773           1776           4          0.6        1773.1       1.0X
+to_unix_timestamp wholestage on                    1775           1784           7          0.6        1774.9       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          282            283           2          3.5         282.3       1.0X
-to date str wholestage on                           266            267           2          3.8         265.9       1.1X
+to date str wholestage off                          271            283          17          3.7         271.2       1.0X
+to date str wholestage on                           262            266           4          3.8         262.2       1.0X
 
 OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aws
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                             3902           3953          71          0.3        3902.4       1.0X
-to_date wholestage on                              3826           3838           9          0.3        3826.5       1.0X
+to_date wholestage off                             3250           3266          23          0.3        3250.2       1.0X
+to_date wholestage on                              3144           3154          13          0.3        3143.7       1.0X
 
 
 ================================================================================================
@@ -444,14 +444,14 @@ OpenJDK 64-Bit Server VM 1.8.0_252-8u252-b09-1~18.04-b09 on Linux 4.15.0-1063-aw
 Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  405            413           9         12.3          81.1       1.0X
-From java.time.LocalDate                            356            359           3         14.1          71.1       1.1X
-Collect java.sql.Date                              1661           2657        1496          3.0         332.2       0.2X
-Collect java.time.LocalDate                        1456           1480          26          3.4         291.3       0.3X
-From java.sql.Timestamp                             258            263           5         19.4          51.6       1.6X
-From java.time.Instant                              247            249           2         20.2          49.4       1.6X
-Collect longs                                      1283           1363          84          3.9         256.6       0.3X
-Collect java.sql.Timestamp                         1462           1492          30          3.4         292.4       0.3X
-Collect java.time.Instant                          1326           1438          97          3.8         265.2       0.3X
+From java.sql.Date                                  413            420          12         12.1          82.5       1.0X
+From java.time.LocalDate                            344            348           4         14.5          68.9       1.2X
+Collect java.sql.Date                              1934           2775        1162          2.6         386.9       0.2X
+Collect java.time.LocalDate                        1441           1469          31          3.5         288.3       0.3X
+From java.sql.Timestamp                             251            256           4         19.9          50.2       1.6X
+From java.time.Instant                              246            253           6         20.4          49.1       1.7X
+Collect longs                                      1332           1403         118          3.8         266.4       0.3X
+Collect java.sql.Timestamp                         1373           1412          39          3.6         274.6       0.3X
+Collect java.time.Instant                          1489           1519          35          3.4         297.7       0.3X
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Regenerated the following benchmarks:
- DateTimeBenchmark

## How was this patch tested?
By running the benchmark in the environment:

| Item | Description |
| ---- | ----|
| Region | us-west-2 (Oregon) |
| Instance | r3.xlarge |
| AMI | ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190722.1 (ami-06f2f779464715dc5) |
| Java | OpenJDK 64-Bit Server VM 1.8.0_242 and OpenJDK 64-Bit Server VM 11.0.6+10 |